### PR TITLE
fix/SA-251 - conditional teams and slack resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,7 @@ Frequently (quartley at least) check and upgrade:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_channels_config"></a> [channels\_config](#output\_channels\_config) | The configuration data for each distribution channel |
+| <a name="output_distributions"></a> [distributions](#output\_distributions) | The list of slack/teams distributions that are managed |
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The ARN of the SNS topic |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -29,19 +29,19 @@ locals {
   teams_webhook_url = local.enable_teams_secret ? try(jsondecode(data.aws_secretsmanager_secret_version.teams[0].secret_string)["webhook_url"], var.teams.webhook_url) : try(var.teams.webhook_url, null)
 
   channels_config = {
-    "slack" = {
+    "slack" = var.slack != null ? {
       webhook_url         = local.slack_webhook_url
       lambda_name         = try(var.slack.lambda_name, "slack-notify")
       lambda_description  = try(var.slack.lambda_description, "Sends posts to slack")
       filter_policy       = try(var.slack.filter_policy, null)
       filter_policy_scope = try(var.slack.filter_policy_scope, null)
-    },
-    "teams" = {
+    } : null,
+    "teams" = var.teams != null ? {
       webhook_url         = local.teams_webhook_url
       lambda_name         = try(var.teams.lambda_name, "teams-notify")
       lambda_description  = try(var.teams.lambda_description, "Sends posts to teams")
       filter_policy       = try(var.teams.filter_policy, null)
       filter_policy_scope = try(var.teams.filter_policy_scope, null)
-    }
+    } : null,
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,6 @@ resource "aws_sns_topic_subscription" "subscribers" {
 # tfsec:ignore:aws-lambda-enable-tracing
 # tfsec:ignore:aws-lambda-restrict-source-arn
 module "notify" {
-  count  = var.enable_slack || var.enable_teams ? 1 : 0
   source = "./modules/notify"
 
   cloudwatch_log_group_kms_key_id        = var.cloudwatch_log_group_kms_key_id

--- a/modules/notify/README.md
+++ b/modules/notify/README.md
@@ -164,7 +164,6 @@ Subsumed by appvia's GNU V3 license; [see license](../../LICENSE).
 | <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | The source path of the custom Lambda function | `string` | `null` | no |
 | <a name="input_post_icons_url"></a> [post\_icons\_url](#input\_post\_icons\_url) | URLs (not base64 encoded!) to publically available icons for highlighting posts of error and/or warning status. Ideally 50px square. | <pre>object({<br>    error_url   = string<br>    warning_url = string<br>  })</pre> | <pre>{<br>  "error_url": "https://raw.githubusercontent.com/appvia/terraform-aws-notifications/main/resources/posts-attention-icon.png",<br>  "warning_url": "https://raw.githubusercontent.com/appvia/terraform-aws-notifications/main/resources/posts-warning-icon.png"<br>}</pre> | no |
 | <a name="input_powertools_layer_arn_suffix"></a> [powertools\_layer\_arn\_suffix](#input\_powertools\_layer\_arn\_suffix) | The suffix of the ARN to use for AWS Powertools lambda layer (must match the architecture:https://docs.powertools.aws.dev/lambda/python/latest/. | `string` | `"AWSLambdaPowertoolsPythonV2-Arm64:79"` | no |
-| <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_python_runtime"></a> [python\_runtime](#input\_python\_runtime) | The lambda python runtime | `string` | `"python3.12"` | no |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations | `number` | `-1` | no |
@@ -186,6 +185,7 @@ Subsumed by appvia's GNU V3 license; [see license](../../LICENSE).
 
 | Name | Description |
 |------|-------------|
+| <a name="output_distributions"></a> [distributions](#output\_distributions) | The list of slack/teams distributions that are managed |
 | <a name="output_notify_slack_lambda_function_arn"></a> [notify\_slack\_lambda\_function\_arn](#output\_notify\_slack\_lambda\_function\_arn) | The ARN of the Lambda function |
 | <a name="output_notify_slack_lambda_function_version"></a> [notify\_slack\_lambda\_function\_version](#output\_notify\_slack\_lambda\_function\_version) | Latest published version of your Lambda function |
 | <a name="output_notify_slack_slack_lambda_function_name"></a> [notify\_slack\_slack\_lambda\_function\_name](#output\_notify\_slack\_slack\_lambda\_function\_name) | The name of the Lambda function |

--- a/modules/notify/main.tf
+++ b/modules/notify/main.tf
@@ -77,7 +77,7 @@ locals {
     }
   )
 
-  # the enable_[slack|teams] variable controls the subsubcription between SNS and lambda only; it is
+  # the enable_[slack|teams] variable controls the subscription between SNS and lambda only; it is
   #  feasible that we want to keep the infrastructure (lambda, lambda role, log group et al) while suspending
   #  the posts.
   # but we only want to create the infrastructure if details of slack or team have been defined

--- a/modules/notify/main.tf
+++ b/modules/notify/main.tf
@@ -86,7 +86,7 @@ locals {
     "teams" = var.delivery_channels["teams"] != null ? true : false,
   }
 
-  distributions = toset([ for x in ["slack", "teams"]:  x if local.create_distribution[x] == true ])
+  distributions = toset([for x in ["slack", "teams"] : x if local.create_distribution[x] == true])
 }
 
 data "aws_iam_policy_document" "lambda" {
@@ -139,7 +139,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_teams" {
-  count = var.create && var.enable_teams  && local.create_distribution["teams"] == true ? 1 : 0
+  count = var.create && var.enable_teams && local.create_distribution["teams"] == true ? 1 : 0
 
   topic_arn           = local.sns_topic_arn
   protocol            = "lambda"

--- a/modules/notify/outputs.tf
+++ b/modules/notify/outputs.tf
@@ -3,7 +3,7 @@ output "sns_topic_arn" {
   value       = local.sns_topic_arn
 }
 
-output distributions {
+output "distributions" {
   description = "The list of slack/teams distributions that are managed"
   value       = local.distributions
 }

--- a/modules/notify/outputs.tf
+++ b/modules/notify/outputs.tf
@@ -3,31 +3,36 @@ output "sns_topic_arn" {
   value       = local.sns_topic_arn
 }
 
+output distributions {
+  description = "The list of slack/teams distributions that are managed"
+  value       = local.distributions
+}
+
 output "notify_slack_lambda_function_arn" {
   description = "The ARN of the Lambda function"
-  value       = module.lambda["slack"].lambda_function_arn
+  value       = try(module.lambda["slack"].lambda_function_arn, "")
 }
 output "notify_teams_lambda_function_arn" {
   description = "The ARN of the Lambda function"
-  value       = module.lambda["teams"].lambda_function_arn
+  value       = try(module.lambda["teams"].lambda_function_arn, "")
 }
 
 output "notify_slack_slack_lambda_function_name" {
   description = "The name of the Lambda function"
-  value       = module.lambda["slack"].lambda_function_name
+  value       = try(module.lambda["slack"].lambda_function_name, "")
 }
 output "notify_teams_slack_lambda_function_name" {
   description = "The name of the Lambda function"
-  value       = module.lambda["teams"].lambda_function_name
+  value       = try(module.lambda["teams"].lambda_function_name, "")
 }
 
 output "notify_slack_lambda_function_version" {
   description = "Latest published version of your Lambda function"
-  value       = module.lambda["slack"].lambda_function_version
+  value       = try(module.lambda["slack"].lambda_function_version, "")
 }
 output "notify_teams_lambda_function_version" {
   description = "Latest published version of your Lambda function"
-  value       = module.lambda["teams"].lambda_function_version
+  value       = try(module.lambda["teams"].lambda_function_version, "")
 }
 
 output "slack_lambda_cloudwatch_log_group_arn" {

--- a/modules/notify/variables.tf
+++ b/modules/notify/variables.tf
@@ -28,12 +28,6 @@ variable "create_sns_topic" {
   default     = true
 }
 
-variable "hash_extra" {
-  description = "The string to add into hashing function. Useful when building same source path for different functions."
-  type        = string
-  default     = ""
-}
-
 variable "lambda_role" {
   description = "IAM role attached to the Lambda Function.  If this is set then a role will not be created for you."
   type        = string
@@ -121,12 +115,6 @@ variable "sns_topic_lambda_feedback_sample_rate" {
   description = "The percentage of successful deliveries to log"
   type        = number
   default     = 100
-}
-
-variable "slack_emoji" {
-  description = "A custom emoji that will appear on Slack messages"
-  type        = string
-  default     = ":aws:"
 }
 
 variable "kms_key_arn" {
@@ -278,17 +266,6 @@ variable "aws_powertools_service_name" {
   description = "The service name to use"
   type        = string
   default     = "appvia-notifications"
-}
-
-variable "aws_powertools_log_level" {
-  description = "The log level for aws powertools"
-  type        = string
-  default     = "DEBUG"
-
-  validation {
-    condition     = contains(["TRACE", "DEBUG", "INFO", "WARNING", "ERROR"], var.aws_powertools_log_level)
-    error_message = "Valid values are TRACE, DEBUG, INFO, WARNING, ERROR"
-  }
 }
 
 variable "accounts_id_to_name" {

--- a/modules/notify/variables.tf
+++ b/modules/notify/variables.tf
@@ -1,9 +1,3 @@
-variable "putin_khuylo" {
-  description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
-  type        = bool
-  default     = true
-}
-
 variable "architecture" {
   description = "Instruction set architecture for your Lambda function. Valid values are \"x86_64\" or \"arm64\"."
   type        = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,14 @@
-
 output "sns_topic_arn" {
   description = "The ARN of the SNS topic"
   value       = local.sns_topic_arn
+}
+
+output distributions {
+  description = "The list of slack/teams distributions that are managed"
+  value       = try(module.notify.distributions, "")
+}
+
+output channels_config {
+  description = "The configuration data for each distribution channel"
+  value       = local.channels_config
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,12 +3,12 @@ output "sns_topic_arn" {
   value       = local.sns_topic_arn
 }
 
-output distributions {
+output "distributions" {
   description = "The list of slack/teams distributions that are managed"
   value       = try(module.notify.distributions, "")
 }
 
-output channels_config {
+output "channels_config" {
   description = "The configuration data for each distribution channel"
   value       = local.channels_config
 }


### PR DESCRIPTION
Now only creates slack or teams infrastructure if `slack` or `teams` is defined. The `enable_slack` and `enable_teams` are still used to toggle subscriptions.

Includes removing unused variables as a result of running "tflint" locally.